### PR TITLE
Add compatibility with nikic/php-parser v5 and phpstan/phpdoc-parser v2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,11 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }} Test on ubuntu latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }} Test on ubuntu latest
 
     steps:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -38,4 +38,5 @@ jobs:
       run: composer run-script phpstan
 
     - name: Check code style
+      if: matrix.php-versions == '8.1'
       run: composer run test:cs

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -13,11 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: [ '8.0', '8.1' ]
+        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
     name: PHP ${{ matrix.php-versions }} Test on ubuntu latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.2', '8.3', '8.4' ]
     name: PHP ${{ matrix.php-versions }} Test on ubuntu latest
 
     steps:
@@ -37,6 +37,3 @@ jobs:
     - name: Run phpstan
       run: composer run-script phpstan
 
-    - name: Check code style
-      if: matrix.php-versions == '8.1'
-      run: composer run test:cs

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
     "require": {
         "php": ">=8.0",
-        "nikic/php-parser": "^4.16",
+        "nikic/php-parser": "^4.16|^5.0",
         "webmozart/assert": "^1.10",
         "jfcherng/php-diff": "^6.10",
         "jawira/case-converter": "^3.4",
-        "phpstan/phpdoc-parser": "^1.6",
+        "phpstan/phpdoc-parser": "^1.6|^2.0",
         "doctrine/inflector": "^2.0",
         "composer/xdebug-handler": "^3.0",
         "symfony/console": "^5.3|^6.3|^6.2|^6.1|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php-parser-dump": "vendor/bin/php-parse tests/Fixtures/NestedDto.php"
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "nikic/php-parser": "^4.16|^5.0",
         "webmozart/assert": "^1.10",
         "jfcherng/php-diff": "^6.10",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,7 @@ includes:
 
 parameters:
     level: 6
-    checkGenericClassInNonGenericObjectType: false
     ignoreErrors:
         - '#Constant [a-zA-Z0-9\\_]+::[a-zA-Z_0-9]+ is unused.#'
+        -
+            identifier: missingType.generics

--- a/src/Ast/Converter.php
+++ b/src/Ast/Converter.php
@@ -20,7 +20,7 @@ class Converter
         /** @var ConverterVisitor[] */
         private array $visitors,
     ) {
-        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $this->parser = (new ParserFactory())->createForHostVersion();
     }
 
     /** @param string[]|iterable $listings */

--- a/src/Ast/DtoVisitor.php
+++ b/src/Ast/DtoVisitor.php
@@ -66,7 +66,7 @@ class DtoVisitor extends ConverterVisitor
                 $propertyName = $stmt->consts[0]->name->name;
                 /** @var string|number|null $notNullValue */
                 $notNullValue = $stmt->consts[0]->value->value ?? null;
-                $isNullValue = ($stmt->consts[0]->value->name->parts[0] ?? null) === 'null';
+                $isNullValue = ((string) ($stmt->consts[0]->value->name ?? null) === 'null');
                 if ($notNullValue === null && $isNullValue === false) {
                     throw new Exception(sprintf("Property %s of enum is different from number, string and null.", $propertyName));
                 }

--- a/src/Ast/DtoVisitor.php
+++ b/src/Ast/DtoVisitor.php
@@ -6,9 +6,11 @@ namespace Riverwaysoft\PhpConverter\Ast;
 
 use Exception;
 use PhpParser\Node;
+use PhpParser\Modifiers;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use Riverwaysoft\PhpConverter\Dto\DtoClassProperty;
 use Riverwaysoft\PhpConverter\Dto\DtoEnumProperty;
 use Riverwaysoft\PhpConverter\Dto\DtoType;
@@ -47,7 +49,7 @@ class DtoVisitor extends ConverterVisitor
 
         $this->createDtoType($node);
 
-        return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+        return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
     }
 
     private function createDtoType(Class_|Enum_ $node): void
@@ -105,7 +107,7 @@ class DtoVisitor extends ConverterVisitor
                 /** @var DtoClassProperty[]|null $classMethodCommentsParsed */
                 $classMethodCommentsParsed = null;
                 foreach ($stmt->params as $param) {
-                    if (!($param->flags & Node\Stmt\Class_::MODIFIER_PUBLIC)) {
+                    if (!($param->flags & Modifiers::PUBLIC)) {
                         continue;
                     }
 

--- a/src/Ast/DtoVisitor.php
+++ b/src/Ast/DtoVisitor.php
@@ -148,7 +148,7 @@ class DtoVisitor extends ConverterVisitor
             if (!$expr) {
                 throw new Exception(sprintf("Non-backed enums are not supported because they are not serializable. Please use backed enums: %s\n Error in enum: %s", 'https://www.php.net/manual/en/language.enumerations.backed.php', $propertyName));
             }
-            if (!$expr instanceof Node\Scalar\LNumber && !$expr instanceof Node\Scalar\String_) {
+            if (!$expr instanceof Node\Scalar\Int_ && !$expr instanceof Node\Scalar\String_) {
                 throw new Exception(sprintf('A backed enum should be type of int or string, %s given. Error in enum %s', get_class($expr), $propertyName));
             }
             $propertyValue = $expr->value;

--- a/src/Ast/PhpDocTypeParser.php
+++ b/src/Ast/PhpDocTypeParser.php
@@ -21,6 +21,7 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 use Riverwaysoft\PhpConverter\Dto\DtoClassProperty;
 use Riverwaysoft\PhpConverter\Dto\PhpType\PhpListType;
 use Riverwaysoft\PhpConverter\Dto\PhpType\PhpOptionalType;
@@ -38,10 +39,11 @@ class PhpDocTypeParser
 
     public function __construct()
     {
-        $this->lexer = new Lexer();
-        $constExprParser = new ConstExprParser();
-        $typeParser = new TypeParser($constExprParser);
-        $this->phpDocParser = new PhpDocParser($typeParser, $constExprParser);
+        $config = new ParserConfig([]);
+        $this->lexer = new Lexer($config);
+        $constExprParser = new ConstExprParser($config);
+        $typeParser = new TypeParser($config, $constExprParser);
+        $this->phpDocParser = new PhpDocParser($config, $typeParser, $constExprParser);
     }
 
     /** @return DtoClassProperty[] */

--- a/src/Bridge/ApiPlatform/ApiPlatformDtoResourceVisitor.php
+++ b/src/Bridge/ApiPlatform/ApiPlatformDtoResourceVisitor.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Attribute;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\PrettyPrinter\Standard;
 use Riverwaysoft\PhpConverter\Ast\ConverterResult;
 use Riverwaysoft\PhpConverter\Ast\ConverterVisitor;
@@ -145,11 +146,11 @@ class ApiPlatformDtoResourceVisitor extends ConverterVisitor
             }
         }
 
-        return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+        return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
     }
 
     private function createApiEndpoint(
-        Node\Expr\ArrayItem $item,
+        Node\ArrayItem $item,
         Class_ $node,
         string|null $defaultOutput,
         string|null $defaultInput,
@@ -244,7 +245,7 @@ class ApiPlatformDtoResourceVisitor extends ConverterVisitor
     }
 
     private function createApiEndpointFromLegacyCode(
-        Node\Expr\ArrayItem $item,
+        Node\ArrayItem $item,
         bool $isCollection,
         Class_ $node,
         string|null $defaultOutput,
@@ -332,7 +333,7 @@ class ApiPlatformDtoResourceVisitor extends ConverterVisitor
     }
 
     /**
-     * @param Node\Expr\ArrayItem[] $arrayItems
+     * @param Node\ArrayItem[] $arrayItems
      */
     private function findArrayAttributeValueByKey(string $key, array $arrayItems): string|null
     {

--- a/src/Bridge/Symfony/SymfonyControllerVisitor.php
+++ b/src/Bridge/Symfony/SymfonyControllerVisitor.php
@@ -9,6 +9,7 @@ use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use Riverwaysoft\PhpConverter\Ast\ClassName;
 use Riverwaysoft\PhpConverter\Ast\ConverterResult;
 use Riverwaysoft\PhpConverter\Ast\ConverterVisitor;
@@ -59,7 +60,7 @@ class SymfonyControllerVisitor extends ConverterVisitor
 
         $this->createApiEndpoint($node);
 
-        return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+        return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
     }
 
     private function findAttribute(ClassMethod|Node\Param $node, string $name): Attribute|null


### PR DESCRIPTION
Add compatibility with nikic/php-parser v5 and phpstan/phpdoc-parser v2
- Widen version constraints: php-parser ^4.16|^5.0, phpdoc-parser ^1.6|^2.0
- Converter: replace removed ParserFactory::PREFER_PHP7 constant with
  createForHostVersion() (php-parser v5 API)
- DtoVisitor: replace Node\Scalar\LNumber with Node\Scalar\Int_
  (renamed in php-parser v5)
- PhpDocTypeParser: pass ParserConfig to Lexer, ConstExprParser,
  TypeParser and PhpDocParser constructors (required in phpdoc-parser v2)